### PR TITLE
massage tox list -- our dep is unfortunately 27 only

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27 flake8
+envlist = py27, flake8
 
 [testenv:flake8]
 basepython=python


### PR DESCRIPTION
What & Why
------------
Our dependency is unfortunately python 2.7 only.
We will make a github issue to either make our dependencies support python 3+ or remove the dependency.