### PR TITLE
Remove unsupported python versions from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,10 +46,6 @@ setup(
         'Intended Audience :: Developers',
         'Natural Language :: English',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
     ],
     test_suite='tests',
     tests_require=test_requirements


### PR DESCRIPTION
What & Why
-------------
Remove unsupported python versions :-( 
We will make a Github issue to properly support python 3. As is, one of our dependencies is python 2.7.
