### PR TITLE
INFRA-2975: Update haproxy stat monitoring

### DIFF
--- a/check_haproxy_stats/__init__.py
+++ b/check_haproxy_stats/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Monetate, Inc."""
 __email__ = 'devops@monetate.com'
-__version__ = '3.1.0'
+__version__ = '3.2.0'

--- a/check_haproxy_stats/haproxy_util.py
+++ b/check_haproxy_stats/haproxy_util.py
@@ -15,10 +15,9 @@ def get_request_stats(backend, base_url_path="127.0.0.1/haproxy/stats", username
     for b in h.backends:
         if b.name.startswith(backend):
             matches.append((b.hrsp_1xx, b.hrsp_2xx, b.hrsp_3xx, b.hrsp_4xx, b.hrsp_5xx, b.hrsp_other))
-    if len(matches) == 0:
-        raise ValueError("Did not find {0} backend".format(backend))
-    else:
-        return tuple(map(sum, zip(*matches)))
+    if not matches:
+        raise ValueError("Did not find backends starting with {0}".format(backend))
+    return tuple(map(sum, zip(*matches)))
 
 
 def get_hrsp_5xx_ratio(backend, base_url_path, username, password, interval):

--- a/check_haproxy_stats/haproxy_util.py
+++ b/check_haproxy_stats/haproxy_util.py
@@ -11,17 +11,14 @@ def get_request_stats(backend, base_url_path="127.0.0.1/haproxy/stats", username
     :rtype: :py:class:`tuple(int, int, int, int, int, int)`
     """
     h = haproxystats.HAProxyServer(base_url_path, username, password)
-    sums = (0, 0, 0, 0, 0, 0)
-    matched = False
+    matches = []
     for b in h.backends:
-        if not b.name.startswith(backend):
-            continue
-        sums = tuple(map(sum, zip(sums, (b.hrsp_1xx, b.hrsp_2xx, b.hrsp_3xx, b.hrsp_4xx, b.hrsp_5xx, b.hrsp_other))))
-        matched = True
-    if not matched:
+        if b.name.startswith(backend):
+            matches.append((b.hrsp_1xx, b.hrsp_2xx, b.hrsp_3xx, b.hrsp_4xx, b.hrsp_5xx, b.hrsp_other))
+    if len(matches) == 0:
         raise ValueError("Did not find {0} backend".format(backend))
     else:
-        return sums
+        return tuple(map(sum, zip(*matches)))
 
 
 def get_hrsp_5xx_ratio(backend, base_url_path, username, password, interval):

--- a/check_haproxy_stats/haproxy_util.py
+++ b/check_haproxy_stats/haproxy_util.py
@@ -11,11 +11,17 @@ def get_request_stats(backend, base_url_path="127.0.0.1/haproxy/stats", username
     :rtype: :py:class:`tuple(int, int, int, int, int, int)`
     """
     h = haproxystats.HAProxyServer(base_url_path, username, password)
+    sums = (0, 0, 0, 0, 0, 0)
+    matched = False
     for b in h.backends:
-        if b.name != backend:
+        if not b.name.startswith(backend):
             continue
-        return (b.hrsp_1xx, b.hrsp_2xx, b.hrsp_3xx, b.hrsp_4xx, b.hrsp_5xx, b.hrsp_other)
-    raise ValueError("Did not find {0} backend".format(backend))
+        sums = tuple(map(sum, zip(sums, (b.hrsp_1xx, b.hrsp_2xx, b.hrsp_3xx, b.hrsp_4xx, b.hrsp_5xx, b.hrsp_other))))
+        matched = True
+    if not matched:
+        raise ValueError("Did not find {0} backend".format(backend))
+    else:
+        return sums
 
 
 def get_hrsp_5xx_ratio(backend, base_url_path, username, password, interval):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.1.0
+current_version = 3.2.0
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ test_requirements = [
 
 setup(
     name='check_haproxy_stats',
-    version='3.1.0',
+    version='3.2.0',
     description="Check HAProxy related statistics",
     long_description=readme + '\n\n' + history,
     author="Monetate, Inc.",


### PR DESCRIPTION
### Why?

Support monitoring 5xx rate across all striped trk backends,
 i.e. trk-1, trk-2, trk-1-degraded, trk-2-degraded, ...

Currently the balancer monitors 5xx rate for 'trk' and 'check-trk' backends only.
We want to avoid having to change the balancer role monitoring as we output new balancer cfg files.

### What?

Treats the --backend option as a backend prefix, summing all stats for backends matching that prefix.