### PR TITLE
add check-haproxy-stats-up to check percent (or absolute) services in each backend that are down

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,6 +10,9 @@ insert_final_newline = true
 charset = utf-8
 end_of_line = lf
 
+[*.py]
+max_line_length = 119
+
 [*.bat]
 indent_style = tab
 end_of_line = crlf

--- a/check_haproxy_stats/check_haproxy_stats_up.py
+++ b/check_haproxy_stats/check_haproxy_stats_up.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+import argparse
+from collections import defaultdict
+import sys
+
+import haproxystats
+
+
+class SensuCheckStatus:
+    RETURN_CODES = {'OK': 0, 'WARNING': 1, 'CRITICAL': 2, 'UNKNOWN': 3}
+    status = RETURN_CODES['OK']
+
+    def update_status(self, new_status, message):
+        if self.RETURN_CODES[new_status] > self.status:
+            self.status = self.RETURN_CODES[new_status]
+        print('{}: {}'.format(new_status, message))
+
+
+def get_haproxy_services_up_count_for_backends(base_url_path, username=None, password=None, backends=None):
+    hs = haproxystats.HAProxyServer(base_url_path, username, password)
+    found_backend_stats = defaultdict(dict)
+    for listener in hs.listeners:  # a list of services found
+        if not backends or listener.pxname in backends:
+            backend = found_backend_stats[listener.pxname]
+            if 'count' not in backend:
+                backend['count'] = 0
+                backend['up_count'] = 0
+            backend['count'] += 1
+            if 'UP' in listener.status:
+                backend['up_count'] += 1
+    return found_backend_stats
+
+
+def check_haproxy_up_rates(
+        base_url_path, username=None, password=None, backends=None, warning_percent=0.9, critical_percent=0.6,
+        warning_down=None, critical_down=None):
+    sensu_status = SensuCheckStatus()
+    try:
+        found_backend_stats = get_haproxy_services_up_count_for_backends(base_url_path, username, password, backends)
+    except Exception as ex:
+        sensu_status.update_status('UNKNOWN', 'Unknown exception: {}'.format(str(ex)))
+        return sensu_status.status
+
+    if backends and len(found_backend_stats.keys()) != len(backends):
+        # Critial, there is a backend not found that was explicitly listed to monitor
+        missing_backends = set(backends) - set(found_backend_stats.keys())
+        sensu_status.update_status('CRITICAL', 'There are missing backends that were requested to be monitored: {}'.format(missing_backends))
+
+    for backend_name in found_backend_stats:
+        backend = found_backend_stats[backend_name]
+        up_percent = float(backend['up_count']) / backend['count']
+        down_count = backend['count'] - backend['up_count']
+        if up_percent < critical_percent:
+            sensu_status.update_status(
+                'CRITICAL',
+                'Backend {} has a critical percentage of services up ({}%)'.format(backend_name, int(up_percent * 100)))
+        elif up_percent < warning_percent:
+            sensu_status.update_status(
+                'WARNING',
+                'Backend {} has a warning percentage of services up ({}%)'.format(backend_name, int(up_percent * 100)))
+        if critical_down and down_count >= critical_down:
+            sensu_status.update_status(
+                'CRITICAL',
+                'Backend {} has a critical number of services down ({})'.format(backend_name, down_count))
+        elif warning_down and down_count >= warning_down:
+            sensu_status.update_status(
+                'WARNING',
+                'Backend {} has a warning number of services down ({})'.format(backend_name, down_count))
+
+    return sensu_status.status
+
+
+def _get_parser():
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument("--base-url-path", default="127.0.0.1/haproxy/stats")
+    parser.add_argument("--username", help="Username to login to haproxy stats page.")
+    parser.add_argument("--password", help="Password to login to haproxy stats page.")
+    parser.add_argument(
+        "--backend", dest="backends", action="append", default=[],
+        help="Backend to check up percent. Defaults to all backends")
+    parser.add_argument(
+        "--warning-percent", type=float, default=0.9,
+        help="Up percentage (non-inclusive), below which we should throw warning.")
+    parser.add_argument(
+        "--critical-percent", type=float, default=0.6,
+        help="Up percentage (non-inclusive), below which we should throw critical.")
+    parser.add_argument(
+        "--warning-down", type=int, help="Down count at or above which we should throw warning.")
+    parser.add_argument(
+        "--critical-down", type=int, help="Down count at or above which we should throw critical.")
+    return parser
+
+
+def main():
+    """Parser user input and execute the check.
+
+    :return: Exit code (depending on severity).
+    :rtype: :py:class:`int`
+    """
+    parser = _get_parser()
+    args = parser.parse_args()
+    rc = check_haproxy_up_rates(
+        base_url_path=args.base_url_path,
+        username=args.username,
+        password=args.password,
+        backends=args.backends,
+        warning_percent=args.warning_percent,
+        critical_percent=args.critical_percent,
+        warning_down=args.warning_down,
+        critical_down=args.critical_down,
+    )
+    return rc
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/check_haproxy_stats/check_haproxy_stats_up.py
+++ b/check_haproxy_stats/check_haproxy_stats_up.py
@@ -44,7 +44,12 @@ def check_haproxy_up_rates(
         sensu_status.update_status('UNKNOWN', 'Unknown exception: {}'.format(str(ex)))
         return sensu_status.status
 
-    if backends and len(found_backend_stats.keys()) != len(backends):
+    if backends:  # if we get extra backends from get_haproxy_services_up_count_for_backends, delete them (e.g. tests)
+        extra_backends = set(found_backend_stats.keys()) - set(backends)
+        for extra_backend in extra_backends:
+            del found_backend_stats[extra_backend]
+
+    if backends and set(found_backend_stats.keys()) != set(backends):
         # Critial, there is a backend not found that was explicitly listed to monitor
         missing_backends = set(backends) - set(found_backend_stats.keys())
         sensu_status.update_status('CRITICAL', 'There are missing backends that were requested to be monitored: {}'.format(missing_backends))

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ test_requirements = [
 
 setup(
     name='check_haproxy_stats',
-    version='3.3.0',
+    version='3.4.0',
     description="Check HAProxy related statistics",
     long_description=readme + '\n\n' + history,
     author="Monetate, Inc.",

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
         'console_scripts': [
             "check-haproxy-stats-5xx = check_haproxy_stats.check_haproxy_stats_5xx:main",
             "metrics-haproxy-stats-5xx = check_haproxy_stats.metrics_haproxy_stats_5xx:main",
+            "check-haproxy-stats-up = check_haproxy_stats.check_haproxy_stats_up:main",
         ],
     },
     include_package_data=True,

--- a/tests/test_check_haproxy_stats_up.py
+++ b/tests/test_check_haproxy_stats_up.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Tests for `check_haproxy_stats_5xx` module."""
+import sys
+import unittest
+
+from check_haproxy_stats import check_haproxy_stats_up
+from mock import patch
+
+
+class TestCheck_haproxy_stats_up(unittest.TestCase):
+    """Test cases for check_haproxy_stats_up."""
+
+    def test_check_haproxy_percents_test_ok(self):
+        """
+        Test 0.90 up percent with warning ratio and critical ratio of 0.90 and 0.60.
+
+        check_haproxy_up_rates should return OK code.
+        """
+        with patch("check_haproxy_stats.check_haproxy_stats_up.get_haproxy_services_up_count_for_backends") as get_backend_counts:
+            get_backend_counts.return_value = {
+                'backend-1': {
+                    'count': 2,
+                    'up_count': 2,
+                },
+                'backend-2': {
+                    'count': 100,
+                    'up_count': 90,  # below 90% will cause percent down warning
+                }
+            }
+            r = check_haproxy_stats_up.check_haproxy_up_rates(
+                base_url_path="127.0.0.1/haproxy/stats",
+                warning_percent=0.90,
+                critical_percent=0.60,
+                )
+            self.assertEqual(r, check_haproxy_stats_up.SensuCheckStatus.RETURN_CODES["OK"])
+
+    def test_check_haproxy_percents_test_warn(self):
+        """
+        Test 0.75 and 0.90 up percent with warning ratio and critical ratio of 0.90 and 0.60.
+
+        check_haproxy_up_rates should return WARNING code.
+        """
+        with patch("check_haproxy_stats.check_haproxy_stats_up.get_haproxy_services_up_count_for_backends") as get_backend_counts:
+            get_backend_counts.return_value = {
+                'backend-1': {
+                    'count': 4,
+                    'up_count': 3,  # 75% will cause a warning
+                },
+                'backend-2': {
+                    'count': 100,
+                    'up_count': 90,  # below 90% will cause percent down warning
+                }
+            }
+            r = check_haproxy_stats_up.check_haproxy_up_rates(
+                base_url_path="127.0.0.1/haproxy/stats",
+                warning_percent=0.90,
+                critical_percent=0.60,
+                )
+            self.assertEqual(r, check_haproxy_stats_up.SensuCheckStatus.RETURN_CODES["WARNING"])
+
+    def test_check_haproxy_percents_test_critical(self):
+        """
+        Test 0.50 and .61 up percent with warning ratio and critical ratio of 0.90 and 0.60.
+
+        check_haproxy_up_rates should return CRITICAL code.
+        """
+        with patch("check_haproxy_stats.check_haproxy_stats_up.get_haproxy_services_up_count_for_backends") as get_backend_counts:
+            get_backend_counts.return_value = {
+                'backend-1': {
+                    'count': 4,
+                    'up_count': 2,  # 50% will cause a critical
+                },
+                'backend-2': {
+                    'count': 100,
+                    'up_count': 61,  # below 61% will cause percent down warning
+                }
+            }
+            r = check_haproxy_stats_up.check_haproxy_up_rates(
+                base_url_path="127.0.0.1/haproxy/stats",
+                warning_percent=0.90,
+                critical_percent=0.60,
+                )
+            self.assertEqual(r, check_haproxy_stats_up.SensuCheckStatus.RETURN_CODES["CRITICAL"])
+
+    def test_check_haproxy_down_test_ok(self):
+        """
+        Test 0 down return OK
+
+        check_haproxy_up_rates should return OK code.
+        """
+        with patch("check_haproxy_stats.check_haproxy_stats_up.get_haproxy_services_up_count_for_backends") as get_backend_counts:
+            get_backend_counts.return_value = {
+                'backend-1': {
+                    'count': 2,
+                    'up_count': 2,
+                },
+                'backend-2': {
+                    'count': 100,
+                    'up_count': 100,
+                }
+            }
+            r = check_haproxy_stats_up.check_haproxy_up_rates(
+                base_url_path="127.0.0.1/haproxy/stats",
+                warning_percent=0.10,
+                critical_percent=0.10,
+                warning_down=1,
+                critical_down=16,
+                )
+            self.assertEqual(r, check_haproxy_stats_up.SensuCheckStatus.RETURN_CODES["OK"])
+
+    def test_check_haproxy_down_test_warn(self):
+        """
+        Test 10 down on one backend and 1 down on another backend causes warning >= 1 down
+
+        check_haproxy_up_rates should return WARNING code.
+        """
+        with patch("check_haproxy_stats.check_haproxy_stats_up.get_haproxy_services_up_count_for_backends") as get_backend_counts:
+            get_backend_counts.return_value = {
+                'backend-1': {
+                    'count': 2,
+                    'up_count': 1,
+                },
+                'backend-2': {
+                    'count': 100,
+                    'up_count': 90,
+                }
+            }
+            r = check_haproxy_stats_up.check_haproxy_up_rates(
+                base_url_path="127.0.0.1/haproxy/stats",
+                warning_percent=0.10,
+                critical_percent=0.10,
+                warning_down=1,
+                critical_down=16,
+                )
+            self.assertEqual(r, check_haproxy_stats_up.SensuCheckStatus.RETURN_CODES["WARNING"])
+
+    def test_check_haproxy_down_test_critical(self):
+        """
+        Test 25 down on one backend and 1 down on another backend causes critical >= 16 down
+
+        check_haproxy_up_rates should return CRITICAL code.
+        """
+        with patch("check_haproxy_stats.check_haproxy_stats_up.get_haproxy_services_up_count_for_backends") as get_backend_counts:
+            get_backend_counts.return_value = {
+                'backend-1': {
+                    'count': 2,
+                    'up_count': 1,
+                },
+                'backend-2': {
+                    'count': 100,
+                    'up_count': 75,
+                }
+            }
+            r = check_haproxy_stats_up.check_haproxy_up_rates(
+                base_url_path="127.0.0.1/haproxy/stats",
+                warning_percent=0.10,
+                critical_percent=0.10,
+                warning_down=1,
+                critical_down=16,
+                )
+            self.assertEqual(r, check_haproxy_stats_up.SensuCheckStatus.RETURN_CODES["CRITICAL"])
+
+    def test_check_haproxy_percents_for_backend_test_ok(self):
+        """
+        Test backend-1 check only tests backend-1 up percent with warning ratio and critical ratio of 0.90 and 0.60.
+
+        check_haproxy_up_rates should return OK code.
+        """
+        with patch("check_haproxy_stats.check_haproxy_stats_up.get_haproxy_services_up_count_for_backends") as get_backend_counts:
+            get_backend_counts.return_value = {
+                'backend-1': {
+                    'count': 2,
+                    'up_count': 2,
+                },
+                'backend-2': {
+                    'count': 100,
+                    'up_count': 3,
+                }
+            }
+            r = check_haproxy_stats_up.check_haproxy_up_rates(
+                base_url_path="127.0.0.1/haproxy/stats",
+                warning_percent=0.90,
+                critical_percent=0.60,
+                backends=['backend-1', ]
+                )
+            self.assertEqual(r, check_haproxy_stats_up.SensuCheckStatus.RETURN_CODES["OK"])
+
+    def test_check_haproxy_critical_if_backend_not_found(self):
+        """
+        Test CRITICAL if backend in check list not found
+
+        check_haproxy_up_rates should return CRITICAL code.
+        """
+        with patch("check_haproxy_stats.check_haproxy_stats_up.get_haproxy_services_up_count_for_backends") as get_backend_counts:
+            get_backend_counts.return_value = {
+                'backend-1': {
+                    'count': 2,
+                    'up_count': 2,
+                },
+                'backend-2': {
+                    'count': 100,
+                    'up_count': 90,  # below 90% will cause percent down warning
+                }
+            }
+            r = check_haproxy_stats_up.check_haproxy_up_rates(
+                base_url_path="127.0.0.1/haproxy/stats",
+                warning_percent=0.90,
+                critical_percent=0.60,
+                backends=['backend-1', 'no-such-backend', ]
+                )
+            self.assertEqual(r, check_haproxy_stats_up.SensuCheckStatus.RETURN_CODES["CRITICAL"])


### PR DESCRIPTION
this is made to replace check-haproxy.rb

this adds a sensu check to check the percentage (or absolute number of) services that are down in each backend (or the specified backends)
