### PR TITLE
Remove calls to gmetric.

### DIFF
--- a/check_haproxy_stats/__init__.py
+++ b/check_haproxy_stats/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Monetate, Inc."""
 __email__ = 'devops@monetate.com'
-__version__ = '3.6.0'
+__version__ = '3.7.0'

--- a/check_haproxy_stats/__init__.py
+++ b/check_haproxy_stats/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Monetate, Inc."""
 __email__ = 'devops@monetate.com'
-__version__ = '3.2.0'
+__version__ = '3.6.0'

--- a/check_haproxy_stats/metrics_haproxy_stats_5xx.py
+++ b/check_haproxy_stats/metrics_haproxy_stats_5xx.py
@@ -50,13 +50,13 @@ def _report_haproxy_rates(backend, base_url_path, username, password, interval, 
     :return: Exit Code (depending on success)
     :rtype: :py:class:`int`
     """
-    hostname = socket.gethostname()
-    hrsp_5xx_ratio_interval = haproxy_util.get_hrsp_5xx_ratio(backend, base_url_path, username, password, interval)
-    hrsp_5xx_percent_interval = "{0:.2f}".format(hrsp_5xx_ratio_interval * 100)  # convert it to percent
-    command = [gmetric_path, "-d", str(gmetric_dmax), "-x", str(gmetric_tmax), "-n",
-               "haproxy_{0}_{1}_5xx_percent".format(hostname, backend), "-v", str(hrsp_5xx_percent_interval), "-s",
-               "both", "-g", "haproxy", "-t", "float"]
-    subprocess.check_call(command)
+    # hostname = socket.gethostname()
+    # hrsp_5xx_ratio_interval = haproxy_util.get_hrsp_5xx_ratio(backend, base_url_path, username, password, interval)
+    # hrsp_5xx_percent_interval = "{0:.2f}".format(hrsp_5xx_ratio_interval * 100)  # convert it to percent
+    # command = [gmetric_path, "-d", str(gmetric_dmax), "-x", str(gmetric_tmax), "-n",
+    #            "haproxy_{0}_{1}_5xx_percent".format(hostname, backend), "-v", str(hrsp_5xx_percent_interval), "-s",
+    #            "both", "-g", "haproxy", "-t", "float"]
+    # subprocess.check_call(command)
     return 0
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.6.0
+current_version = 3.7.0
 commit = True
 tag = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.2.0
+current_version = 3.6.0
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ test_requirements = [
 
 setup(
     name='check_haproxy_stats',
-    version='3.6.0',
+    version='3.7.0',
     description="Check HAProxy related statistics",
     long_description=readme + '\n\n' + history,
     author="Monetate, Inc.",

--- a/tests/test_metrics_haproxy_stats_5xx.py
+++ b/tests/test_metrics_haproxy_stats_5xx.py
@@ -27,6 +27,7 @@ class TestMetrics_Haproxy_Stats_5xx(unittest.TestCase):
         self.assertEqual(args.gmetric_tmax, 1)
         self.assertEqual(args.gmetric_dmax, 2)
 
+    @unittest.skip("gmetric reporting disabled")
     @patch("check_haproxy_stats.haproxy_util.get_hrsp_5xx_ratio")
     @patch("subprocess.check_call")
     @patch("socket.gethostname")


### PR DESCRIPTION
### Why?

Reduce costs by removing legacy ganglia monitoring systems.

### What?

Disable all calls to the gmetric application so it may be removed.